### PR TITLE
fix userprofile edit

### DIFF
--- a/src/Controller/Rest/UserController.php
+++ b/src/Controller/Rest/UserController.php
@@ -131,6 +131,17 @@ class UserController extends AbstractFOSRestController
             $update->setPassword($hasher->hash($update->getPassword()));
         }
 
+        // Workaround for not persisting empty Strings into the DB
+        if ($update->getPostcode() === '') {$update->setPostcode(null);}
+        if ($update->getCity() === '') {$update->setCity(null);}
+        if ($update->getStreet() === '') {$update->setStreet(null);}
+        if ($update->getCountry() === '') {$update->setCountry(null);}
+        if ($update->getPhone() === '') {$update->setPhone(null);}
+        if ($update->getWebsite() === '') {$update->setWebsite(null);}
+        if ($update->getSteamAccount() === '') {$update->setSteamAccount(null);}
+        if ($update->getHardware() === '') {$update->setHardware(null);}
+        if ($update->getStatements() === '') {$update->setStatements(null);}
+
         $this->em->persist($update);
         $this->em->flush();
 


### PR DESCRIPTION
Changes are needed in both KLMS and IDM

KLMS: Fixes not being able to clear Fields in the Profile as the null values got eaten by the Serializer

The IDM Part converts the empty Strings back into null so the empty values won't get saved into the DB