### PR TITLE
feat: add battle.net account to gamer profile

### DIFF
--- a/src/Command/UserEditCommand.php
+++ b/src/Command/UserEditCommand.php
@@ -40,6 +40,7 @@ class UserEditCommand extends Command
         $this
             ->addOption('website', null, InputOption::VALUE_REQUIRED, 'Edit Website')
             ->addOption('steamAccount', null, InputOption::VALUE_REQUIRED, 'Edit steamAccount')
+            ->addOption('battlenetAccount', null, InputOption::VALUE_REQUIRED, 'Edit battlenetAccount')
             ->addOption('hardware', null, InputOption::VALUE_REQUIRED, 'Edit Hardware')
             ->addOption('statements', null, InputOption::VALUE_REQUIRED, 'Edit Statements');
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -124,6 +124,11 @@ class User
     #[Assert\Length(max: 255, maxMessage: 'The {{ field }} cannot be longer than {{ limit }} characters', groups: ['Default', 'Transfer', 'Create'])]
     private ?string $steamAccount = null;
 
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[Groups(['read', 'write'])]
+    #[Assert\Length(max: 255, maxMessage: 'The {{ field }} cannot be longer than {{ limit }} characters', groups: ['Default', 'Transfer', 'Create'])]
+    private ?string $battlenetAccount = null;
+
     #[ORM\Column(type: 'string', length: 4096, nullable: true)]
     #[Assert\Length(max: 4096, maxMessage: 'The {{ field }} cannot be longer than {{ limit }} characters', groups: ['Default', 'Transfer', 'Create'])]
     #[Groups(['read', 'write'])]
@@ -350,6 +355,18 @@ class User
     public function setSteamAccount(?string $steamAccount): self
     {
         $this->steamAccount = $steamAccount;
+
+        return $this;
+    }
+
+    public function getBattlenetAccount(): ?string
+    {
+        return $this->battlenetAccount;
+    }
+
+    public function setBattlenetAccount(?string $battlenetAccount): self
+    {
+        $this->battlenetAccount = $battlenetAccount;
 
         return $this;
     }

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -107,6 +107,9 @@ class UserService
         if (null !== $userdata['steamAccount']) {
             $user->setSteamAccount($userdata['steamAccount']);
         }
+        if (null !== $userdata['battlenetAccount']) {
+            $user->setBattlenetAccount($userdata['battlenetAccount']);
+        }
         if (null !== $userdata['hardware']) {
             $user->setHardware($userdata['hardware']);
         }

--- a/tests/UserControllerCreateTest.php
+++ b/tests/UserControllerCreateTest.php
@@ -26,6 +26,7 @@ class UserControllerCreateTest extends AbstractControllerTest
     "phone": "+43 664/1234567",
     "gender": "f",
     "steamAccount": "fup",
+    "battlenetAccount": "fup",
     "hardware": "some old Laptop",
     "statements": "fup fup fup"
 }
@@ -51,6 +52,7 @@ JSON;
         $this->assertArrayHasKey("emailConfirmed", $result);
         $this->assertArrayHasKey("isSuperadmin", $result);
         $this->assertArrayHasKey("steamAccount", $result);
+        $this->assertArrayHasKey("battlenetAccount", $result);
         $this->assertArrayHasKey("registeredAt", $result);
         $this->assertArrayHasKey("modifiedAt", $result);
         $this->assertArrayHasKey("hardware", $result);


### PR DESCRIPTION
Adds battlenet account to gamer profile. 

No specific migration available, I duplicated the steam_account column and named it as `battlenet_account`.

Part 1 of 2 - see also [PR KLMS#118](https://github.com/KRRUg/KLMS/pull/118).